### PR TITLE
fix: 🐛 create .nojekyll file in root folder

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,8 +21,11 @@ yarn install --silent
 printf "\n\nRunning Production Build...\n"
 BRIDGETOWN_ENV=production NODE_ENV=production yarn webpack-build && yarn build
 
-printf "\nCommitting Changes...\n"
+printf "\n\nCreating .nojekyll File...\n"
 cd "${INPUT_BUILD_LOCATION}"
+touch .nojekyll
+
+printf "\nCommitting Changes...\n"
 git init
 git config user.name "${INPUT_GITHUB_ACTOR}"
 git config user.email "${INPUT_GITHUB_ACTOR}@users.noreply.github.com"


### PR DESCRIPTION
## Type of PR

- [ ] feature
- [ ] enhancement
- [x] bug fix
- [ ] other

## Description

Create a .nojekyll file in the root folder of our github pages branch so files and folders starting with an underscore are not ignored

Fixes #2 

**Would need to update the version and create a new release v0.0.3**
