### PR TITLE
Deploy with custom domain (CNAME) on GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ conventional-changelog -p angular -i CHANGELOG.md -s
 conventional-changelog -p angular -i CHANGELOG.md -s -r 0
 ```
 
+## Extras
+
+### Deploy on Github Pages with Custom Domain.
+
+If you are following the [github documentation for add your custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site), GitHub adds the **CNAME** file in the `gh-pages` branch but it will get removed everytime you deploy your web page, to solve this issue, add the **CNAME** file into the **src/** folder and it will be deployed as expected.
+
+
 ## License
 
 This plugin is released under the [MIT License](LICENSE).


### PR DESCRIPTION
example: https://github.com/JuanVqz/juanvqz.github.io

## Type of PR

- [ ] feature
- [ ] enhancement
- [ ] bug fix
- [x] other

## Description

I was searching for a way to don't remove the **CNAME** file on deploy but I think this is an easy way to keep the CNAME in the `gh-pages` branch. 

I'm not sure if this is the best place to put this information. sorry if not.
BTW, thank you for your contributions. 🤟

## Checklist

- [x] I have tested this
- [ ] I have updated the documentation if applicable
